### PR TITLE
init out of stock when stocked fix

### DIFF
--- a/app/(root)/product/[slug]/page.tsx
+++ b/app/(root)/product/[slug]/page.tsx
@@ -60,7 +60,7 @@ const ProductDetailsPage = async (props: {
 						<div>
 							{
 								product.inventory > 0 ?
-									<p className="text-sm">Out of Stock: </p>
+									<p className="text-sm">In Stock: </p>
 								:
 									<Badge variant='destructive'>Out Of Stock</Badge>
 							}


### PR DESCRIPTION
On an individual product item, when the stock is greater than one, the inventory would say out of stock. Now, if the inventory is greater than one then it will show the product is in stock.